### PR TITLE
Fix documentation typo and improve tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,17 +80,15 @@ Enhancement suggestions are welcome! When proposing an enhancement:
 ```text
 auth-framework/
 ├── src/
-│   ├── auth.rs           # Main authentication framework
-│   ├── config.rs         # Configuration management
-│   ├── credentials.rs    # Credential types and handling
-│   ├── errors.rs         # Error types and handling
-│   ├── lib.rs           # Library entry point
-│   ├── methods.rs        # Authentication methods
-│   ├── permissions.rs    # Permission system
-│   ├── providers.rs      # OAuth providers
-│   ├── storage.rs        # Storage backends
-│   ├── tokens.rs         # Token management
-│   └── utils.rs          # Utility functions
+│   ├── auth.rs             # Core authentication framework
+│   ├── audit.rs            # Audit logging
+│   ├── authorization.rs    # Authorization logic
+│   ├── errors.rs           # Error types and handling
+│   ├── lib.rs              # Library entry point
+│   ├── permissions.rs      # Permission system
+│   ├── providers.rs        # OAuth providers
+│   ├── user_context.rs     # Per-request user context
+│   └── utils.rs            # Utility functions
 ├── examples/            # Example code
 └── tests/              # Integration tests
 ```

--- a/docs/quality/documentation-review.md
+++ b/docs/quality/documentation-review.md
@@ -60,7 +60,7 @@ Our documentation follows the **CLEAR** framework:
 - **C**omplete: All necessary information is present
 - **L**ogical: Information is organized logically
 - **E**xact: Information is accurate and precise
-- **A**ccessible: Easy to find and understand
+- **A**ccessible: Easy to find and understand.
 - **R**elevant: Focused on user needs
 
 ### Quality Metrics

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -195,7 +195,7 @@ pub enum AuthError {
 
     /// TOML parsing errors
     #[error("TOML error: {0}")]
-    Toml(#[from] toml::ser::Error),
+    Toml(#[from] toml::de::Error),
 
     /// Prometheus metrics errors
     #[cfg(feature = "prometheus")]

--- a/tests/simple_integration_test.rs
+++ b/tests/simple_integration_test.rs
@@ -19,8 +19,8 @@ async fn test_resource_hierarchy_works() {
 
     // Verify hierarchy exists
     let children = checker.get_child_resources("parent");
-    assert!(children.is_some());
-    assert_eq!(children.unwrap().len(), 1);
+    let children = children.expect("parent should have child resources");
+    assert_eq!(children.len(), 1);
 
     // Test hierarchical permission check (without user assignment)
     let _result = checker.check_hierarchical_permission("admin", "read", "child");


### PR DESCRIPTION
## Summary
- Correct CLEAR acronym documentation typo
- Use `toml::de::Error` for TOML parsing
- Refresh CONTRIBUTING project structure example
- Avoid `unwrap` panic in `simple_integration_test`

## Testing
- `cargo test` *(fails: no variant named `RFC4648` for enum `base32::Alphabet`)*
- `cargo test --locked` *(fails: lock file out of date)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a169c4c0832cbccce7218a3c12e3

## Summary by Sourcery

Fix documentation typo, update project structure example, improve test robustness, and correct TOML error handling

Bug Fixes:
- Use toml::de::Error instead of toml::ser::Error for TOML parsing errors

Enhancements:
- Replace unwrap with expect in simple_integration_test to avoid panic

Documentation:
- Refresh CONTRIBUTING.md project structure example with current modules
- Add missing punctuation in CLEAR acronym documentation

Tests:
- Improve simple_integration_test by providing a clear failure message when child resources are missing